### PR TITLE
Add atmospheric refraction correction to moon altitude

### DIFF
--- a/__tests__/moonPosition.test.js
+++ b/__tests__/moonPosition.test.js
@@ -15,7 +15,7 @@
  */
 
 const SunCalc  = require('suncalc');
-const { calcMoon, radToDeg } = require('../src/moonLogic');
+const { calcMoon, radToDeg, refractionCorrection } = require('../src/moonLogic');
 
 // ── Shared test coordinates ───────────────────────────────────────────────────
 // New York City
@@ -58,9 +58,11 @@ describe('calcMoon() — unit tests with mocked SunCalc', () => {
   });
 
   // ── altitude conversion ───────────────────────────────────────────────────
-  it('converts altitude from radians to degrees correctly (30° above horizon)', () => {
+  it('converts altitude from radians to degrees and applies refraction (30° above horizon)', () => {
+    // Mock returns 30° exactly; refraction at 30° adds ~0.029°, so result > 30
     const result = calcMoon(NYC_LAT, NYC_LON, new Date());
-    expect(result.altDeg).toBeCloseTo(30, 4);
+    expect(result.altDeg).toBeGreaterThan(30);
+    expect(result.altDeg).toBeCloseTo(30, 1); // within 0.1° of 30
   });
 
   it('sets isAbove = true when altitude is positive', () => {
@@ -75,11 +77,13 @@ describe('calcMoon() — unit tests with mocked SunCalc', () => {
     expect(result.isAbove).toBe(false);
   });
 
-  it('sets isAbove = false when moon is exactly on the horizon (0°)', () => {
+  it('moon at geometric horizon (0°) appears above horizon after refraction correction', () => {
+    // Refraction lifts the moon ~0.48° at 0° geometric altitude —
+    // so a moon sitting exactly on the geometric horizon IS actually visible.
     spyPosition.mockReturnValue({ altitude: 0, azimuth: 0 });
     const result = calcMoon(NYC_LAT, NYC_LON, new Date());
-    expect(result.altDeg).toBeCloseTo(0, 4);
-    expect(result.isAbove).toBe(false); // 0 is NOT > 0
+    expect(result.altDeg).toBeGreaterThan(0);
+    expect(result.isAbove).toBe(true);
   });
 
   // ── azimuth conversion ────────────────────────────────────────────────────
@@ -162,6 +166,50 @@ describe('calcMoon() — unit tests with mocked SunCalc', () => {
   });
 });
 
+// ── REFRACTION CORRECTION TESTS ──────────────────────────────────────────────
+
+describe('refractionCorrection()', () => {
+  it('returns a positive correction at the horizon (0°)', () => {
+    expect(refractionCorrection(0)).toBeGreaterThan(0);
+  });
+
+  it('returns less than 0.6° at the horizon (physically plausible max)', () => {
+    expect(refractionCorrection(0)).toBeLessThan(0.6);
+  });
+
+  it('returns a smaller correction at 10° than at 0°', () => {
+    expect(refractionCorrection(10)).toBeLessThan(refractionCorrection(0));
+  });
+
+  it('returns less than 0.1° above 20° (negligible in practice)', () => {
+    expect(refractionCorrection(20)).toBeLessThan(0.1);
+  });
+
+  it('returns exactly 0 when moon is well below horizon (-2°)', () => {
+    expect(refractionCorrection(-2)).toBe(0);
+  });
+
+  it('returns exactly 0 for deeply negative altitudes (-45°)', () => {
+    expect(refractionCorrection(-45)).toBe(0);
+  });
+
+  it('correction decreases monotonically from horizon to overhead', () => {
+    const c0  = refractionCorrection(0);
+    const c10 = refractionCorrection(10);
+    const c30 = refractionCorrection(30);
+    const c60 = refractionCorrection(60);
+    expect(c0).toBeGreaterThan(c10);
+    expect(c10).toBeGreaterThan(c30);
+    expect(c30).toBeGreaterThan(c60);
+  });
+
+  it('correction is always positive for altitudes between -1° and 90°', () => {
+    [-1, 0, 5, 10, 30, 60, 90].forEach(alt => {
+      expect(refractionCorrection(alt)).toBeGreaterThanOrEqual(0);
+    });
+  });
+});
+
 // ── INTEGRATION TESTS (real SunCalc) ─────────────────────────────────────────
 
 describe('calcMoon() — integration tests with real SunCalc', () => {
@@ -201,11 +249,14 @@ describe('calcMoon() — integration tests with real SunCalc', () => {
       expect(result.isAbove).toBe(result.altDeg > 0);
     });
 
-    it('transformation matches direct SunCalc call (altitude)', () => {
+    it('altDeg is higher than raw SunCalc altitude by the refraction amount', () => {
       const rawPos = SunCalc.getMoonPosition(FULL_MOON_DATE, NYC_LAT, NYC_LON);
-      const expectedAlt = rawPos.altitude * (180 / Math.PI);
+      const rawAlt = rawPos.altitude * (180 / Math.PI);
       const result = calcMoon(NYC_LAT, NYC_LON, FULL_MOON_DATE);
-      expect(result.altDeg).toBeCloseTo(expectedAlt, 4);
+      // Refraction always adds a positive correction
+      expect(result.altDeg).toBeGreaterThanOrEqual(rawAlt);
+      // But never more than 1° higher (max refraction is ~0.57°)
+      expect(result.altDeg - rawAlt).toBeLessThan(1);
     });
 
     it('transformation matches direct SunCalc call (azimuth degrees)', () => {

--- a/src/moonLogic.js
+++ b/src/moonLogic.js
@@ -135,6 +135,29 @@ function getTheme(date, lat, lon) {
 }
 
 /* ================================================================
+   ATMOSPHERIC REFRACTION CORRECTION
+================================================================ */
+
+/**
+ * Estimate the atmospheric refraction correction for a given true altitude.
+ *
+ * The atmosphere bends light upward near the horizon, making the moon appear
+ * higher than its true geometric position. This correction is most significant
+ * near the horizon (~0.57° at 0°) and negligible above ~20°.
+ *
+ * Uses the Bennett formula (1982), accurate to ~0.07 arcminutes.
+ *
+ * @param {number} altDeg – true geometric altitude in degrees
+ * @returns {number}        correction in degrees (always positive; add to altDeg)
+ */
+function refractionCorrection(altDeg) {
+  if (altDeg < -1) return 0; // moon is well below horizon; no correction needed
+  if (altDeg > 89) return 0; // near zenith: correction negligible and formula breaks down
+  const h = Math.max(altDeg, 0); // clamp to 0 for horizon-level calculation
+  return 1.02 / Math.tan(degToRad(h + 10.3 / (h + 5.11))) / 60;
+}
+
+/* ================================================================
    MOON CALCULATION
 ================================================================ */
 
@@ -162,7 +185,7 @@ function calcMoon(lat, lon, date) {
   const illum = SunCalc.getMoonIllumination(now);
   const times = SunCalc.getMoonTimes(now, lat, lon);
 
-  const altDeg = radToDeg(pos.altitude);
+  const altDeg = radToDeg(pos.altitude) + refractionCorrection(radToDeg(pos.altitude));
   const az     = azimuthToCompass(pos.azimuth);
   const isAbove = altDeg > 0;
 
@@ -207,6 +230,7 @@ module.exports = {
   getPhaseName,
   isNighttime,
   getTheme,
+  refractionCorrection,
   calcMoon,
   validateZipCode,
 };


### PR DESCRIPTION
## Summary
- Adds `refractionCorrection()` to `moonLogic.js` using the Bennett (1982) formula
- Applies the correction inside `calcMoon()` so the displayed altitude accounts for atmospheric bending
- Most noticeable near the horizon (~0.57° correction at 0°), negligible above 20°
- Adds guard for altitudes > 89° to prevent formula singularity near zenith

## Test plan
- [ ] 8 new unit tests added for `refractionCorrection()` covering horizon, mid-altitude, zenith, and below-horizon cases
- [ ] 3 existing unit tests updated to reflect corrected altitude values
- [ ] All 161 unit tests passing (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)