### PR TITLE
Fix tilt indicator not showing when moon is below horizon

### DIFF
--- a/index.html
+++ b/index.html
@@ -1186,7 +1186,7 @@ function startTiltDraw() {
     const feedback = $('tilt-feedback');
 
     if (currentMoonAltitude <= 0) {
-      drawAltArc(currentMoonAltitude);
+      drawAltArc(currentMoonAltitude, deviceElevation);
       feedback.textContent = 'Moon is below the horizon';
       feedback.className = 'off';
     } else {


### PR DESCRIPTION
Pass deviceElevation to drawAltArc even when moon is below horizon, so the tilt line still tracks on the arc.