### PR TITLE
Fix tilt elevation direction — beta increases toward sky on iPhone

### DIFF
--- a/__tests__/tilt.test.js
+++ b/__tests__/tilt.test.js
@@ -6,10 +6,11 @@
  * Tests for betaToElevation() — the pure math function that converts a
  * DeviceOrientationEvent beta angle into an elevation angle above the horizon.
  *
- * Convention:
- *   beta ≈ 90 → phone upright  → looking at horizon  → 0° elevation
- *   beta ≈  0 → phone face-up  → looking straight up → 90° elevation
- *   elevation = clamp(90 − beta, 0, 90)
+ * Convention (matches observed iPhone behavior):
+ *   beta ≈  90 → phone upright   → camera at horizon  → 0° elevation
+ *   beta ≈ 180 → phone face-down → camera at sky      → 90° elevation
+ *   beta ≈   0 → phone face-up   → camera at ground   → clamped to 0°
+ *   elevation = clamp(beta − 90, 0, 90)
  */
 
 const { betaToElevation } = require('../src/moonLogic');
@@ -18,44 +19,43 @@ describe('betaToElevation()', () => {
 
   // ── Key reference points ──────────────────────────────────────────────────
 
-  it('returns 0° when phone is upright (beta = 90) — looking at horizon', () => {
+  it('returns 0° when phone is upright (beta = 90) — camera at horizon', () => {
     expect(betaToElevation(90)).toBe(0);
   });
 
-  it('returns 90° when phone is flat face-up (beta = 0) — looking straight up', () => {
-    expect(betaToElevation(0)).toBe(90);
+  it('returns 90° when phone is face-down (beta = 180) — camera pointing at sky', () => {
+    expect(betaToElevation(180)).toBe(90);
   });
 
-  it('returns 45° when phone is at 45° (beta = 45)', () => {
-    expect(betaToElevation(45)).toBe(45);
+  it('returns 45° when phone is at 45° above upright (beta = 135)', () => {
+    expect(betaToElevation(135)).toBe(45);
   });
 
-  it('returns 30° when beta = 60', () => {
-    expect(betaToElevation(60)).toBe(30);
+  it('returns 30° when beta = 120', () => {
+    expect(betaToElevation(120)).toBe(30);
   });
 
-  it('returns 60° when beta = 30', () => {
-    expect(betaToElevation(30)).toBe(60);
+  it('returns 60° when beta = 150', () => {
+    expect(betaToElevation(150)).toBe(60);
   });
 
-  // ── Clamping — below horizon ───────────────────────────────────────────────
+  // ── Clamping — camera below horizon ───────────────────────────────────────
 
-  it('clamps to 0° when phone is past vertical (beta = 100) — pointing downward', () => {
-    expect(betaToElevation(100)).toBe(0);
+  it('clamps to 0° when phone is slightly above upright (beta = 100) — still near horizon', () => {
+    expect(betaToElevation(100)).toBe(10);
   });
 
-  it('clamps to 0° for large beta values (beta = 180)', () => {
-    expect(betaToElevation(180)).toBe(0);
+  it('clamps to 0° when phone is face-up (beta = 0) — camera pointing at ground', () => {
+    expect(betaToElevation(0)).toBe(0);
+  });
+
+  it('clamps to 0° for beta below 90 (phone not yet tilted toward sky)', () => {
+    expect(betaToElevation(45)).toBe(0);
+    expect(betaToElevation(80)).toBe(0);
   });
 
   it('clamps to 0° for negative beta (phone tilted forward past vertical)', () => {
-    expect(betaToElevation(-10)).toBe(90); // 90 - (-10) = 100, clamped to 90
-  });
-
-  // ── Clamping — above zenith ───────────────────────────────────────────────
-
-  it('clamps to 90° for very negative beta values', () => {
-    expect(betaToElevation(-45)).toBe(90);
+    expect(betaToElevation(-10)).toBe(0);
   });
 
   // ── Output range ─────────────────────────────────────────────────────────
@@ -70,10 +70,10 @@ describe('betaToElevation()', () => {
 
   // ── Monotonicity ──────────────────────────────────────────────────────────
 
-  it('elevation decreases as beta increases (tilting phone down lowers elevation)', () => {
-    expect(betaToElevation(0)).toBeGreaterThan(betaToElevation(30));
-    expect(betaToElevation(30)).toBeGreaterThan(betaToElevation(60));
-    expect(betaToElevation(60)).toBeGreaterThan(betaToElevation(89));
+  it('elevation increases as beta increases (tilting phone toward sky raises elevation)', () => {
+    expect(betaToElevation(120)).toBeGreaterThan(betaToElevation(100));
+    expect(betaToElevation(150)).toBeGreaterThan(betaToElevation(120));
+    expect(betaToElevation(180)).toBeGreaterThan(betaToElevation(150));
   });
 
 });

--- a/__tests_verify__/verification.spec.js
+++ b/__tests_verify__/verification.spec.js
@@ -1182,9 +1182,9 @@ test.describe('[FTM-TG-002] Tilt indicator draws on arc regardless of moon visib
 // ══════════════════════════════════════════════════════════════════════════════
 
 // Mock moon altitude: 0.5236 rad ≈ 30° + ~0.03° refraction ≈ 30°
-// betaToElevation(60) = 30° → on target
-// betaToElevation(85) =  5° → tilt up ~25°
-// betaToElevation(20) = 70° → tilt down ~40°
+// betaToElevation(120) = 30° → on target  (beta - 90 = 30)
+// betaToElevation(95)  =  5° → tilt up ~25°  (beta - 90 = 5)
+// betaToElevation(160) = 70° → tilt down ~40°  (beta - 90 = 70)
 
 test.describe('[FTM-TG-003] Tilt feedback text reflects accuracy', () => {
   test('shows "On target" when device elevation matches moon altitude (±3°)', async ({ page }) => {
@@ -1193,7 +1193,7 @@ test.describe('[FTM-TG-003] Tilt feedback text reflects accuracy', () => {
     await setupAndEnterZip(page, SUNCALC_DAY);
     await expect(page.locator('#tilt-section')).toHaveClass(/visible/, { timeout: 3000 });
     await page.click('#tilt-toggle-btn');
-    await dispatchTiltEvent(page, 60); // elevation ≈ 30° = moon altitude
+    await dispatchTiltEvent(page, 120); // elevation = beta-90 = 30° ≈ moon altitude
     await expect(page.locator('#tilt-feedback'))
       .toContainText(/on target/i, { timeout: 3000 });
   });
@@ -1204,7 +1204,7 @@ test.describe('[FTM-TG-003] Tilt feedback text reflects accuracy', () => {
     await setupAndEnterZip(page, SUNCALC_DAY);
     await expect(page.locator('#tilt-section')).toHaveClass(/visible/, { timeout: 3000 });
     await page.click('#tilt-toggle-btn');
-    await dispatchTiltEvent(page, 85); // elevation = 5°, moon at 30° → tilt up
+    await dispatchTiltEvent(page, 95); // elevation = beta-90 = 5°, moon at 30° → tilt up
     await expect(page.locator('#tilt-feedback'))
       .toContainText(/tilt up/i, { timeout: 3000 });
   });
@@ -1215,7 +1215,7 @@ test.describe('[FTM-TG-003] Tilt feedback text reflects accuracy', () => {
     await setupAndEnterZip(page, SUNCALC_DAY);
     await expect(page.locator('#tilt-section')).toHaveClass(/visible/, { timeout: 3000 });
     await page.click('#tilt-toggle-btn');
-    await dispatchTiltEvent(page, 20); // elevation = 70°, moon at 30° → tilt down
+    await dispatchTiltEvent(page, 160); // elevation = beta-90 = 70°, moon at 30° → tilt down
     await expect(page.locator('#tilt-feedback'))
       .toContainText(/tilt down/i, { timeout: 3000 });
   });

--- a/index.html
+++ b/index.html
@@ -1129,8 +1129,8 @@ let deviceBeta    = 90;   // default = vertical = 0° elevation
 let tiltAnimFrame = null;
 
 function betaToElevation(beta) {
-  // beta ≈ 90 = upright (horizon, 0°); beta ≈ 0 = face-up (zenith, 90°)
-  return Math.max(0, Math.min(90, 90 - beta));
+  // beta ≈ 90 = upright (horizon, 0°); beta ≈ 180 = face-down (camera at sky, 90°)
+  return Math.max(0, Math.min(90, beta - 90));
 }
 
 function handleTiltEvent(e) {

--- a/src/moonLogic.js
+++ b/src/moonLogic.js
@@ -211,9 +211,10 @@ function calcMoon(lat, lon, date) {
 /**
  * Convert a DeviceOrientation beta angle to an elevation angle above the horizon.
  *
- * When holding a phone in portrait mode pointed at the sky:
- *   beta ≈ 90 → phone upright  → looking at horizon   → 0° elevation
- *   beta ≈  0 → phone face-up  → looking straight up  → 90° elevation
+ * On iOS/Android, beta increases as you tilt the top of the phone away from you:
+ *   beta ≈  90 → phone upright  → looking at horizon   → 0° elevation
+ *   beta ≈ 180 → phone face-down → camera points at sky → 90° elevation
+ *   beta ≈   0 → phone face-up  → camera points at ground → clamped to 0°
  *
  * Result is clamped to [0, 90] — we only track above-horizon angles.
  *
@@ -221,7 +222,7 @@ function calcMoon(lat, lon, date) {
  * @returns {number}      elevation angle in degrees [0, 90]
  */
 function betaToElevation(beta) {
-  return Math.max(0, Math.min(90, 90 - beta));
+  return Math.max(0, Math.min(90, beta - 90));
 }
 
 /* ================================================================


### PR DESCRIPTION
## Bug
Holding the phone upright showed 0° (correct), but tilting **down toward the ground** increased the reading to 90°, while tilting **up toward the sky** showed nothing (stuck at 0°). The directions were completely flipped.

## Root cause
The formula assumed `beta` **decreases** as you tilt toward the sky, but on iPhone it **increases**:

| Phone position | beta | Old formula `90 - beta` | New formula `beta - 90` |
|---|---|---|---|
| Upright (horizon) | 90° | 0° ✓ | 0° ✓ |
| Tilted up to sky | ~180° | `90-180 = -90` → **0°** ✗ | `180-90 = 90°` ✓ |
| Tilted down to ground | ~0° | `90-0 = 90°` ✗ | `0-90 = -90` → **0°** ✓ |

## Changes
- `src/moonLogic.js` — formula changed from `90 - beta` to `beta - 90`
- `index.html` — same fix in the inline copy of `betaToElevation()`
- `__tests__/tilt.test.js` — unit tests updated to reflect correct direction
- `__tests_verify__/verification.spec.js` — TG-003 beta values corrected

## Test plan
- [x] All 79 verification tests pass (`npm run test:verify`)
- [x] TG-003 "On target / Tilt up / Tilt down" tests pass with new beta values

🤖 Generated with [Claude Code](https://claude.com/claude-code)