### PR TITLE
Fix day-theme readability for warning text and altitude arc

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,11 +420,12 @@
 
     #compass-tilt-warning {
       font-size: 0.75rem;
-      color: #fbbf24;
       text-align: center;
       margin-top: 0.25rem;
       display: none;
     }
+    body.night #compass-tilt-warning { color: #fbbf24; }
+    body.day   #compass-tilt-warning { color: #dc2626; }
     #compass-tilt-warning.visible { display: block; }
 
     /* ─── Tilt Guide ─────────────────────────────────────────────── */
@@ -836,6 +837,7 @@ function drawAltArc(altDeg, deviceElevation) {
   const W = canvas.width, H = canvas.height;
   ctx.clearRect(0, 0, W, H);
 
+  const isDark = document.body.classList.contains('night');
   const cx = W / 2, cy = H - 10;
   const radius = 80;
 
@@ -843,14 +845,14 @@ function drawAltArc(altDeg, deviceElevation) {
   ctx.beginPath();
   ctx.moveTo(cx - radius - 20, cy);
   ctx.lineTo(cx + radius + 20, cy);
-  ctx.strokeStyle = 'rgba(255,255,255,0.2)';
+  ctx.strokeStyle = isDark ? 'rgba(255,255,255,0.2)' : 'rgba(15,23,42,0.2)';
   ctx.lineWidth = 1.5;
   ctx.stroke();
 
   // Arc background (below)
   ctx.beginPath();
   ctx.arc(cx, cy, radius, Math.PI, 0, false);
-  ctx.strokeStyle = 'rgba(255,255,255,0.08)';
+  ctx.strokeStyle = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(15,23,42,0.1)';
   ctx.lineWidth = 6;
   ctx.lineCap = 'round';
   ctx.stroke();
@@ -870,7 +872,6 @@ function drawAltArc(altDeg, deviceElevation) {
   if (altDeg >= 0) {
     ctx.beginPath();
     ctx.arc(cx, cy, radius, Math.PI, moonAngle, true);
-    const isDark = document.body.classList.contains('night');
     const grad = ctx.createLinearGradient(cx - radius, cy, cx, cy - radius);
     grad.addColorStop(0, isDark ? '#7c3aed' : '#2563eb');
     grad.addColorStop(1, isDark ? '#a78bfa' : '#60a5fa');
@@ -886,7 +887,6 @@ function drawAltArc(altDeg, deviceElevation) {
   // Draw moon circle
   ctx.beginPath();
   ctx.arc(moonX, cy - radius * Math.sin(Math.PI - moonAngle), 9, 0, Math.PI * 2);
-  const isDark = document.body.classList.contains('night');
   ctx.fillStyle = isDark ? '#f0e6c8' : '#fbbf24';
   ctx.shadowColor = isDark ? 'rgba(240,230,200,0.6)' : 'rgba(251,191,36,0.6)';
   ctx.shadowBlur = 12;
@@ -900,7 +900,7 @@ function drawAltArc(altDeg, deviceElevation) {
     const dx = cx + radius * Math.cos(devAngle);
     const dy = cy - radius * Math.sin(Math.PI - devAngle);
     const diff = Math.abs(deviceElevation - altDeg);
-    const tiltColor = diff <= 3 ? '#34d399' : diff <= 12 ? '#fbbf24' : 'rgba(255,255,255,0.55)';
+    const tiltColor = diff <= 3 ? '#34d399' : diff <= 12 ? '#fbbf24' : isDark ? 'rgba(255,255,255,0.55)' : 'rgba(15,23,42,0.45)';
 
     // Dashed line from centre out to the arc
     ctx.beginPath();
@@ -932,13 +932,13 @@ function drawAltArc(altDeg, deviceElevation) {
     ctx.beginPath();
     ctx.moveTo(x1, y1);
     ctx.lineTo(x2, y2);
-    ctx.strokeStyle = 'rgba(255,255,255,0.25)';
+    ctx.strokeStyle = isDark ? 'rgba(255,255,255,0.25)' : 'rgba(15,23,42,0.3)';
     ctx.lineWidth = 1;
     ctx.stroke();
     // Label
     const lx = cx + (radius + 20) * Math.cos(angle);
     const ly = cy - (radius + 20) * Math.abs(Math.sin(Math.PI - angle));
-    ctx.fillStyle = 'rgba(255,255,255,0.35)';
+    ctx.fillStyle = isDark ? 'rgba(255,255,255,0.5)' : 'rgba(15,23,42,0.65)';
     ctx.font = '10px sans-serif';
     ctx.textAlign = 'center';
     ctx.fillText(a + '°', lx, ly + 4);


### PR DESCRIPTION
## Summary
- Compass tilt warning: was amber (invisible on light background) → now red (`#dc2626`) on day theme, amber on night theme
- Altitude arc: all hardcoded `rgba(255,255,255,...)` colours now adapt to the day theme — horizon line, arc background, tick marks, tick labels (30°/60°/90°), and tilt indicator line are now dark navy on day instead of near-invisible white

## Test plan
- [ ] Check altitude arc in day theme — 30°/60°/90° labels and tick marks are readable
- [ ] Trigger compass tilt warning (enable both compass and tilt guide, tilt above 45°) — text is red and legible in day theme
- [ ] Verify night theme still looks correct (white arc, amber warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)