### PR TITLE
Redesign SDLC sessions: single branch, draft PR, rename labels

### DIFF
--- a/.github/workflows/sdlc-session1.yml
+++ b/.github/workflows/sdlc-session1.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   requirements-and-tests:
-    if: github.event.label.name == 'approved'
+    if: github.event.label.name == 'reqs-ready'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -29,7 +29,7 @@ jobs:
 
       - name: Create branch
         run: |
-          BRANCH="sdlc/issue-${{ github.event.issue.number }}-requirements"
+          BRANCH="sdlc/issue-${{ github.event.issue.number }}"
           git checkout -b "$BRANCH"
           echo "BRANCH=$BRANCH" >> $GITHUB_ENV
 
@@ -49,20 +49,21 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit."
           else
-            git commit -m "SDLC Session 1: requirements and tests for issue #${{ github.event.issue.number }}"
+            git commit -m "SDLC Session 1: requirements and test stubs for issue #${{ github.event.issue.number }}"
             git push origin "$BRANCH"
           fi
 
-      - name: Create PR
+      - name: Open draft PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if git ls-remote --exit-code origin "$BRANCH" > /dev/null 2>&1; then
             gh pr create \
-              --title "SDLC: Requirements & tests for issue #${{ github.event.issue.number }}" \
+              --title "SDLC issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}" \
               --body "$(cat .github/sdlc_pr_body.md)" \
               --base main \
-              --head "$BRANCH"
+              --head "$BRANCH" \
+              --draft
           else
             echo "No changes were pushed — skipping PR creation."
           fi

--- a/.github/workflows/sdlc-session2.yml
+++ b/.github/workflows/sdlc-session2.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: sdlc/issue-${{ github.event.issue.number }}
 
       - uses: actions/setup-python@v5
         with:
@@ -26,12 +28,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Create branch
-        run: |
-          BRANCH="sdlc/issue-${{ github.event.issue.number }}-code"
-          git checkout -b "$BRANCH"
-          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
 
       - name: Run SDLC Session 2
         env:
@@ -48,19 +44,5 @@ jobs:
             echo "No changes to commit."
           else
             git commit -m "SDLC Session 2: code implementation for issue #${{ github.event.issue.number }}"
-            git push origin "$BRANCH"
-          fi
-
-      - name: Create PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if git ls-remote --exit-code origin "$BRANCH" > /dev/null 2>&1; then
-            gh pr create \
-              --title "SDLC: Code implementation for issue #${{ github.event.issue.number }}" \
-              --body "$(cat .github/sdlc_pr_body.md)" \
-              --base main \
-              --head "$BRANCH"
-          else
-            echo "No changes were pushed — skipping PR creation."
+            git push origin sdlc/issue-${{ github.event.issue.number }}
           fi


### PR DESCRIPTION
## Summary
- Session 1 now opens a **draft PR** on branch `sdlc/issue-N` instead of a regular PR
- Sessions 2–5 all commit to the same `sdlc/issue-N` branch — no separate branches per session
- Renamed trigger label from `approved` → `reqs-ready` to match the naming convention of the other session labels
- Session 2 no longer creates its own PR — it just adds commits to the existing draft PR

## Label flow
`reqs-ready` → Session 1 → `code-ready` → Session 2 → `tests-ready` → Session 3 → `security-ready` → Session 4 → `quality-ready` → Session 5 → human reviews draft PR → merge

## Review checklist
- [ ] Session 1 workflow uses `reqs-ready` label and `--draft` flag
- [ ] Session 2 workflow checks out existing branch instead of creating a new one
- [ ] No PR creation step in Session 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)