### PR TITLE
Add SDLC Session 3: Automated Tests GitHub Action

### DIFF
--- a/.github/scripts/sdlc_session3.py
+++ b/.github/scripts/sdlc_session3.py
@@ -1,0 +1,134 @@
+"""
+SDLC Session 3 — Automated Tests
+Triggered by the 'tests-ready' label on a GitHub issue.
+
+Reads the issue + SRS requirements + existing test stubs, calls Claude to
+replace TODO stubs with real working assertions, then writes the changes
+back to disk for the workflow to commit to the shared sdlc/issue-N branch.
+
+Intentionally does NOT read implementation code — tests are written against
+requirements, not against what the code happens to do today.
+"""
+
+import os
+import json
+import anthropic
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def read_file(path, max_chars=None):
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        return content[:max_chars] if max_chars else content
+    except FileNotFoundError:
+        return ''
+
+def write_file(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True) if os.path.dirname(path) else None
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+def apply_replacement(file_path, old_string, new_string):
+    content = read_file(file_path)
+    if not content:
+        raise FileNotFoundError(f"File not found: {file_path}")
+    if old_string not in content:
+        raise ValueError(f"old_string not found in {file_path}:\n{old_string[:200]}")
+    updated = content.replace(old_string, new_string, 1)
+    write_file(file_path, updated)
+    print(f"Patched {file_path}")
+
+# ── context ───────────────────────────────────────────────────────────────────
+
+issue_number = os.environ['ISSUE_NUMBER']
+issue_title  = os.environ['ISSUE_TITLE']
+issue_body   = os.environ.get('ISSUE_BODY', '') or '(no description provided)'
+
+srs_content       = read_file('FTM-SRS-001.md', max_chars=10000)
+jest_tests        = read_file('__tests_verify__/verification.test.js', max_chars=15000)
+playwright_tests  = read_file('__tests_verify__/verification.spec.js', max_chars=15000)
+
+# ── prompt ────────────────────────────────────────────────────────────────────
+
+prompt = f"""You are a test engineer writing automated verification tests for the "Find the Moon" \
+web application — a single-page browser app that shows users where the moon is.
+
+A GitHub issue has been through requirements (Session 1) and code implementation (Session 2). \
+Your job is to replace any TODO test stubs with real, working test assertions.
+
+Issue #{issue_number}: {issue_title}
+{issue_body}
+
+--- SRS requirements (write tests against these, not against the implementation) ---
+{srs_content}
+
+--- Current verification.test.js (Jest — logic layer, no browser) ---
+{jest_tests}
+
+--- Current verification.spec.js (Playwright — browser/UI layer) ---
+{playwright_tests}
+
+Your tasks:
+1. Find any TODO stubs related to this issue in either test file.
+2. Replace each stub with real, working test assertions that verify the requirement is met.
+3. Follow these rules:
+   - Write tests against the SRS requirements — do not test implementation details
+   - Match the existing test style exactly (indentation, describe/it structure, mock patterns)
+   - Jest tests: use pure JS logic, no browser, mock external dependencies
+   - Playwright tests: use page mocks for SunCalc and network calls (follow existing mock patterns)
+   - Tests must be deterministic — no real network calls, no real GPS, no real time
+   - Do not modify any existing passing tests
+   - Do not add new imports or dependencies not already in the file
+
+Return ONLY a valid JSON object — no markdown fences, no preamble — with exactly these keys:
+{{
+  "replacements": [
+    {{
+      "file": "__tests_verify__/verification.test.js or __tests_verify__/verification.spec.js",
+      "old_string": "exact verbatim stub to replace",
+      "new_string": "complete replacement with real assertions"
+    }}
+  ],
+  "summary": "1-2 sentence description of what tests were written"
+}}
+
+If there are no TODO stubs to replace, return an empty replacements array.
+"""
+
+# ── call Claude ───────────────────────────────────────────────────────────────
+
+client = anthropic.Anthropic()
+
+message = client.messages.create(
+    model='claude-sonnet-4-6',
+    max_tokens=8192,
+    messages=[{'role': 'user', 'content': prompt}],
+)
+
+response_text = message.content[0].text
+
+# Extract JSON
+start = response_text.find('{')
+end   = response_text.rfind('}') + 1
+if start < 0 or end <= start:
+    raise ValueError(f"No JSON found in response:\n{response_text[:500]}")
+
+try:
+    data = json.loads(response_text[start:end])
+except json.JSONDecodeError as e:
+    print(f"JSON parse error: {e}")
+    print(f"Response length: {len(response_text)}, stop_reason: {message.stop_reason}")
+    print(f"Response tail: {response_text[-300:]}")
+    raise
+
+# ── apply replacements ────────────────────────────────────────────────────────
+
+replacements = data.get('replacements', [])
+if not replacements:
+    print("No test stubs to replace for this issue.")
+else:
+    for r in replacements:
+        apply_replacement(r['file'], r['old_string'], r['new_string'])
+
+print(data.get('summary', 'Done.'))

--- a/.github/workflows/sdlc-session3.yml
+++ b/.github/workflows/sdlc-session3.yml
@@ -1,0 +1,49 @@
+name: SDLC Session 3 — Automated Tests
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  automated-tests:
+    if: github.event.label.name == 'tests-ready'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: sdlc/issue-${{ github.event.issue.number }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install anthropic
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run SDLC Session 3
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: python3 .github/scripts/sdlc_session3.py
+
+      - name: Commit and push
+        run: |
+          git add __tests_verify__/verification.test.js \
+                  __tests_verify__/verification.spec.js
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "SDLC Session 3: automated tests for issue #${{ github.event.issue.number }}"
+            git push origin sdlc/issue-${{ github.event.issue.number }}
+          fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sdlc-session3.yml` — triggers on `tests-ready` label
- Adds `.github/scripts/sdlc_session3.py` — replaces TODO test stubs with real working assertions

## Key design decisions
- Reads SRS requirements and test stubs only — **no implementation code** — so tests verify requirements, not the current code
- Uses same targeted replacement approach as Session 2 (old_string/new_string) for token efficiency
- Commits to existing `sdlc/issue-N` branch, no new PR

## Review checklist
- [ ] Workflow checks out correct branch (`sdlc/issue-N`)
- [ ] Prompt instructs Claude not to read implementation code
- [ ] No new test dependencies introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)